### PR TITLE
Simplified Bloomfilter and added benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ go-blooms
 ---
 
 From Wiki
->Bloom Filter: A space-efficient probabilistic data structure that is used to test whether an element is a member of 
-a set. False positive matches are possible, but false negatives are not; i.e. a query returns either "possibly in set" 
+>Bloom Filter: A space-efficient probabilistic data structure that is used to test whether an element is a member of
+a set. False positive matches are possible, but false negatives are not; i.e. a query returns either "possibly in set"
 or "definitely not in set". Elements can be added to the set, but not removed.
 
 This bloom filter implementation is backed by bool slice for simplicity.
@@ -24,10 +24,9 @@ import "github.com/theodesp/go-blooms"
 
 const (
   size = 64 * 1024
-  numHashValues = 3
 )
 
-bf := go_blooms.New(size, numHashValues)
+bf := go_blooms.New(size, go_blooms.DefaultHashFunctions)
 
 value := "hello"
 
@@ -48,9 +47,9 @@ if bf.Test([]byte(anotherValue) { // Bloom filter guarantees that anotherValue i
 
 **Time**
 
-If we are using a bloom filter with  bits and  hash function, 
-insertion and search will both take  time. 
-In both cases, we just need to run the input through all of 
+If we are using a bloom filter with  bits and  hash function,
+insertion and search will both take  time.
+In both cases, we just need to run the input through all of
 the hash functions. Then we just check the output bits.
 
 |  Operation | Complexity  |

--- a/bloomFilter.go
+++ b/bloomFilter.go
@@ -9,74 +9,53 @@ import (
 
 // Minimal interface that the Bloom filter must implement
 type Interface interface {
-	Add(item []byte)   		// Adds the item into the Set
-	Test(item []byte) bool  // Performs probabilist test if the item exists in the set or not.
+	Add(item []byte)       // Adds the item into the Set
+	Test(item []byte) bool // Performs probabilist test if the item exists in the set or not.
 }
 
 // BloomFilter probabilistic data structure definition
 type BloomFilter struct {
-	bitset []bool      // The bloom-filter bitset
-	k      uint         // Number of hash values
-	n      uint         // Number of elements in the filter
-	m      uint         // Size of the bloom filter
+	bitset  []bool        // The bloom-filter bitset
+	n       uint          // Number of elements in the filter
+	m       uint          // Size of the bloom filter
 	hashfns []hash.Hash64 // The hash functions
 }
 
+// DefaultHashFunctions for BloomFilter
+var DefaultHashFunctions = []hash.Hash64{murmur3.New64(), fnv.New64(), fnv.New64a()}
+
 // Returns a new BloomFilter object,
-func New(size, numHashValues uint) *BloomFilter {
+func New(size uint, hashes []hash.Hash64) *BloomFilter {
 	return &BloomFilter{
-		bitset: make([]bool, size),
-		k: numHashValues,
-		m: size,
-		n: uint(0),
-		hashfns: []hash.Hash64{murmur3.New64(), fnv.New64(), fnv.New64a()},
+		bitset:  make([]bool, size),
+		m:       size,
+		n:       uint(0),
+		hashfns: hashes,
 	}
 }
 
 // Adds the item into the bloom filter set by hashing in over the hash functions
 func (bf *BloomFilter) Add(item []byte) {
-	hashes := bf.hashValues(item)
-	i := uint(0)
-
-	for {
-		if i >= bf.k {
-			break
-		}
-
-		position := uint(hashes[i]) % bf.m
-		bf.bitset[uint(position)] = true
-
-		i+= 1
+	for _, v := range bf.hashValues(item) {
+		position := uint(v) % bf.m
+		bf.bitset[position] = true
 	}
-
 	bf.n += 1
 }
 
 // Test if the item into the bloom filter is set by hashing in over the hash functions
-func (bf *BloomFilter) Test(item []byte) (exists bool) {
-	hashes := bf.hashValues(item)
-	i := uint(0)
-	exists = true
-
-	for {
-		if i >= bf.k {
-			break
-		}
-
-		position := uint(hashes[i]) % bf.m
+func (bf *BloomFilter) Test(item []byte) bool {
+	for _, v := range bf.hashValues(item) {
+		position := uint(v) % bf.m
 		if !bf.bitset[uint(position)] {
-			exists = false
-			break
+			return false
 		}
-
-		i+= 1
 	}
-
-	return
+	return true
 }
 
 // Calculates all the hash values by hashing in over the hash functions
-func (bf *BloomFilter) hashValues(item []byte) []uint64  {
+func (bf *BloomFilter) hashValues(item []byte) []uint64 {
 	var result []uint64
 
 	for _, hashFunc := range bf.hashfns {
@@ -87,4 +66,3 @@ func (bf *BloomFilter) hashValues(item []byte) []uint64  {
 
 	return result
 }
-

--- a/bloomFilter_test.go
+++ b/bloomFilter_test.go
@@ -1,9 +1,11 @@
 package go_blooms
 
 import (
+	"fmt"
 	"hash"
 	"hash/fnv"
 	"math/rand"
+	"sort"
 	"testing"
 
 	"github.com/spaolacci/murmur3"
@@ -66,6 +68,29 @@ func BenchmarkSearch(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		// Logic to benchmark
 		bf.Test([]byte(string(i) + " foo baz"))
+	}
+}
+
+// Compare with a binary sort to make sure we're in the same ballpark
+func BenchmarkBinarySearch(b *testing.B) {
+	randomString := func() string {
+		return fmt.Sprintf("%q", randomBytes(20))
+	}
+
+	var strings []string
+	for i := 0; i < 100000; i++ {
+		item := randomString()
+		strings = append(strings, item)
+	}
+
+	// Sort by byte order
+	sort.Strings(strings)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		item := randomString()
+		use(sort.SearchStrings(strings, item))
 	}
 }
 

--- a/bloomFilter_test.go
+++ b/bloomFilter_test.go
@@ -1,7 +1,6 @@
 package go_blooms
 
 import (
-	"fmt"
 	"hash"
 	"hash/fnv"
 	"math/rand"
@@ -11,15 +10,18 @@ import (
 	"github.com/spaolacci/murmur3"
 )
 
-// 1 Million
-var memberSize uint = 1000000
+// 100 Million
+var memberSize uint = 100000000
+
+// 100 Thousand
+var sampleSize int = 100000
 
 // Test items if items may exist into set
 func TestExistance(t *testing.T) {
 	bf := New(memberSize, DefaultHashFunctions)
 
-	for i := 0; i < 1000; i++ {
-		item := randomBytes(rand.Intn(54) + 10)
+	for i := 0; i < sampleSize; i++ {
+		item := randomBytes(10)
 
 		bf.Add(item)
 
@@ -28,7 +30,7 @@ func TestExistance(t *testing.T) {
 		}
 
 		// Now lets create some items that don't exist
-		item2 := append(item, randomBytes(rand.Intn(54)+10)...)
+		item2 := append(item, randomBytes(10)...)
 
 		// Test that item does NOT exist
 		if bf.Test(item2) == true {
@@ -40,45 +42,25 @@ func TestExistance(t *testing.T) {
 func BenchmarkAdd(b *testing.B) {
 	bf := New(memberSize, DefaultHashFunctions)
 	for i := 0; i < b.N; i++ {
-		// Logic to benchmark
-		bf.Add([]byte(string(i)))
+		bf.Add(randomBytes(10))
 	}
 }
 
 func BenchmarkTest(b *testing.B) {
 	bf := New(memberSize, DefaultHashFunctions)
 	for i := 0; i < b.N; i++ {
-		// Logic to benchmark
-		bf.Add([]byte(string(i)))
+		bf.Add(randomBytes(10))
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		// Logic to benchmark
-		bf.Test([]byte(string(i)))
-	}
-}
-
-func BenchmarkSearch(b *testing.B) {
-	bf := New(memberSize, DefaultHashFunctions)
-	for i := 0; i < b.N; i++ {
-		// Logic to benchmark
-		bf.Add([]byte(string(i) + " foo bar baz"))
-	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		// Logic to benchmark
-		bf.Test([]byte(string(i) + " foo baz"))
+		bf.Test(randomBytes(10))
 	}
 }
 
 // Compare with a binary sort to make sure we're in the same ballpark
 func BenchmarkBinarySearch(b *testing.B) {
-	randomString := func() string {
-		return fmt.Sprintf("%q", randomBytes(20))
-	}
-
 	var strings []string
-	for i := 0; i < 100000; i++ {
+	for i := 0; i < sampleSize; i++ {
 		item := randomString()
 		strings = append(strings, item)
 	}
@@ -120,4 +102,8 @@ func randomBytes(size int) []byte {
 	b := make([]byte, size)
 	rand.Read(b)
 	return b
+}
+
+func randomString() string {
+	return string(randomBytes(10))
 }


### PR DESCRIPTION
- Instead of passing a number (max value of 3) for how many hash functions you want, pass the hash functions themselves. 
- Provide benchmarks
- Test with larger lookup loads (10k)
- Simplify design


